### PR TITLE
feat: replace "#!/bin/bash" with portable shebang

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 ARCH=$(uname -m)

--- a/test-server/start-linux.sh
+++ b/test-server/start-linux.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 ./xmlui-test-server-linux-amd64 -api api.json

--- a/test-server/start-macos-arm64.sh
+++ b/test-server/start-macos-arm64.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Remove quarantine attribute for Gatekeeper, if present

--- a/test-server/start-macos-intel.sh
+++ b/test-server/start-macos-intel.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Remove quarantine attribute for Gatekeeper, if present


### PR DESCRIPTION
This is for POSIX compatibility. It will affect a minority of people (I happen to be one of them on NixOs), but for them, it will be appreciated. The first paragraph of [this comment](https://github.com/actions/runner/issues/565#issuecomment-667651399) is relevant to us, linux packaging is not.
It should definitely work on MacOs as well, but I only have my Linux machine to try it out.
